### PR TITLE
Remove unused methods from the project

### DIFF
--- a/OpenCore Configurator/AppDelegate.swift
+++ b/OpenCore Configurator/AppDelegate.swift
@@ -17,11 +17,6 @@ var shouldExit = false
 class AppDelegate: NSObject, NSApplicationDelegate {
 
 
-
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Insert code here to initialize your application
-        
-    }
     
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
         path = filename
@@ -58,10 +53,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return NSApplication.TerminateReply.terminateCancel
     }
     
-    func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
-    }
-
     @IBAction func newFile(_ sender: Any) {
         let vc = NSStoryboard(name: "Main", bundle: nil).instantiateController(withIdentifier: "mainVC") as! ViewController
         let newWindow = NSWindow(contentViewController: vc)

--- a/OpenCore Configurator/Info.plist
+++ b/OpenCore Configurator/Info.plist
@@ -25,8 +25,6 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/OpenCore Configurator/ViewController.swift
+++ b/OpenCore Configurator/ViewController.swift
@@ -142,11 +142,7 @@ class ViewController: NSViewController {
     var uefiQuirks: [String: NSButton] = [String: NSButton]()
     var topLevelBools: [NSButton: Bool] = [NSButton: Bool]()
     var uefiProtocols: [String: NSButton] = [String: NSButton]()
-    
-    func windowShouldClose() {
-        
-    }
-    
+
     var dragDropKernelAdd = NSPasteboard.PasteboardType(rawValue: "private.table-row.kernelAdd")
     var dragDropAcpiPatch = NSPasteboard.PasteboardType(rawValue: "private.table-row.acpiPatch")
     var dragDropKernelPatch = NSPasteboard.PasteboardType(rawValue: "private.table-row.kernelPatch")


### PR DESCRIPTION
This PR removes a few methods that were unused - the app delegate methods appear to be part of the boilerplate included with Xcode's default file templates.