### PR TITLE
Implement data model using Codable

### DIFF
--- a/OpenCore Configurator.xcodeproj/project.pbxproj
+++ b/OpenCore Configurator.xcodeproj/project.pbxproj
@@ -17,6 +17,14 @@
 		810042441ECA33DF009FE633 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810042431ECA33DF009FE633 /* AppDelegate.swift */; };
 		810042461ECA33DF009FE633 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810042451ECA33DF009FE633 /* ViewController.swift */; };
 		8100424B1ECA33DF009FE633 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 810042491ECA33DF009FE633 /* Main.storyboard */; settings = {ASSET_TAGS = (0, ); }; };
+		901FF74B228C322B0068449B /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF74A228C322B0068449B /* Configuration.swift */; };
+		901FF74D228C35870068449B /* ACPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF74C228C35870068449B /* ACPI.swift */; };
+		901FF74F228C360F0068449B /* DeviceProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF74E228C360F0068449B /* DeviceProperties.swift */; };
+		901FF751228C36190068449B /* Kernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF750228C36190068449B /* Kernel.swift */; };
+		901FF753228C36280068449B /* Miscellaneous.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF752228C36280068449B /* Miscellaneous.swift */; };
+		901FF755228C363D0068449B /* NVRAM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF754228C363D0068449B /* NVRAM.swift */; };
+		901FF757228C36440068449B /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF756228C36440068449B /* PlatformInfo.swift */; };
+		901FF759228C364B0068449B /* UEFI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901FF758228C364B0068449B /* UEFI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +40,14 @@
 		810042471ECA33DF009FE633 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8100424A1ECA33DF009FE633 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8100424C1ECA33DF009FE633 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		901FF74A228C322B0068449B /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		901FF74C228C35870068449B /* ACPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPI.swift; sourceTree = "<group>"; };
+		901FF74E228C360F0068449B /* DeviceProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperties.swift; sourceTree = "<group>"; };
+		901FF750228C36190068449B /* Kernel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kernel.swift; sourceTree = "<group>"; };
+		901FF752228C36280068449B /* Miscellaneous.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Miscellaneous.swift; sourceTree = "<group>"; };
+		901FF754228C363D0068449B /* NVRAM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NVRAM.swift; sourceTree = "<group>"; };
+		901FF756228C36440068449B /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
+		901FF758228C364B0068449B /* UEFI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UEFI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +85,7 @@
 				810042451ECA33DF009FE633 /* ViewController.swift */,
 				810042471ECA33DF009FE633 /* Assets.xcassets */,
 				810042491ECA33DF009FE633 /* Main.storyboard */,
+				901FF749228C32190068449B /* Model */,
 				8100424C1ECA33DF009FE633 /* Info.plist */,
 				7F4C29DD2269FD2900720E68 /* Extensions.swift */,
 				7F4C29E1226A130A00720E68 /* AcpiPopoverController.swift */,
@@ -77,6 +94,21 @@
 				7F3AAC172279BB55006644AD /* saveHandlerFunctions.swift */,
 			);
 			path = "OpenCore Configurator";
+			sourceTree = "<group>";
+		};
+		901FF749228C32190068449B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				901FF74A228C322B0068449B /* Configuration.swift */,
+				901FF74C228C35870068449B /* ACPI.swift */,
+				901FF74E228C360F0068449B /* DeviceProperties.swift */,
+				901FF750228C36190068449B /* Kernel.swift */,
+				901FF752228C36280068449B /* Miscellaneous.swift */,
+				901FF754228C363D0068449B /* NVRAM.swift */,
+				901FF756228C36440068449B /* PlatformInfo.swift */,
+				901FF758228C364B0068449B /* UEFI.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -154,13 +186,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				901FF757228C36440068449B /* PlatformInfo.swift in Sources */,
+				901FF74F228C360F0068449B /* DeviceProperties.swift in Sources */,
 				7FF918A9227226A60081891E /* openHandlerFunctions.swift in Sources */,
+				901FF753228C36280068449B /* Miscellaneous.swift in Sources */,
 				810042461ECA33DF009FE633 /* ViewController.swift in Sources */,
+				901FF755228C363D0068449B /* NVRAM.swift in Sources */,
 				7F3AAC182279BB55006644AD /* saveHandlerFunctions.swift in Sources */,
 				7F961CCC2270974E007F0BBE /* KernelPopoverController.swift in Sources */,
 				7F4C29DE2269FD2900720E68 /* Extensions.swift in Sources */,
 				7F4C29E2226A130A00720E68 /* AcpiPopoverController.swift in Sources */,
+				901FF74D228C35870068449B /* ACPI.swift in Sources */,
+				901FF74B228C322B0068449B /* Configuration.swift in Sources */,
 				810042441ECA33DF009FE633 /* AppDelegate.swift in Sources */,
+				901FF759228C364B0068449B /* UEFI.swift in Sources */,
+				901FF751228C36190068449B /* Kernel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenCore Configurator/Model/ACPI.swift
+++ b/OpenCore Configurator/Model/ACPI.swift
@@ -1,0 +1,93 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct ACPI: Codable {
+    var additions: [Addition]?
+    var blocks: [Block]?
+    var patches: [Patch]?
+    var quirks: Quirks?
+
+    private enum CodingKeys: String, CodingKey {
+        case additions = "Add"
+        case blocks = "Block"
+        case patches = "Patch"
+        case quirks = "Quirk"
+    }
+
+    struct Addition: Codable {
+        var comment: String?
+        var isEnabled: Bool = false
+        var path: String
+
+        private enum CodingKeys: String, CodingKey {
+            case comment = "Comment"
+            case isEnabled = "Enabled"
+            case path = "Path"
+        }
+    }
+
+    struct Block: Codable {
+        var blockAll: Bool? = false
+        var comment: String?
+        var isEnabled: Bool? = false
+        var oemTableIdentifier: Data? = Data(repeating: 0, count: 8)
+        var tableLength: Int? = 0
+        var tableSignature: Data? = Data(repeating: 0, count: 4)
+
+        private enum CodingKeys: String, CodingKey {
+            case blockAll = "All"
+            case comment = "Comment"
+            case isEnabled = "Enabled"
+            case oemTableIdentifier = "OemTableId"
+            case tableLength = "TableLength"
+            case tableSignature = "TableSignature"
+        }
+    }
+
+    struct Patch: Codable {
+        var comment: String?
+        var count: Int? = 0
+        var isEnabled: Bool? = false
+        var find: Data?
+        var limit: Int? = 0
+        var mask: Data?
+        var oemTableIdentifier: Data? = Data(repeating: 0, count: 8)
+        var replace: Data?
+        var replaceMask: Data?
+        var skip: Int? = 0
+        var tableLength: Int? = 0
+        var tableSignature: Data? = Data(repeating: 0, count: 4)
+
+        private enum CodingKeys: String, CodingKey {
+            case comment = "Comment"
+            case count = "Count"
+            case isEnabled = "Enabled"
+            case find = "Find"
+            case limit = "Limit"
+            case mask = "Mask"
+            case oemTableIdentifier = "OemTableId"
+            case replace = "Replace"
+            case replaceMask = "ReplaceMask"
+            case skip = "Skip"
+            case tableLength = "TableLength"
+            case tableSignature = "TableSignature"
+        }
+    }
+
+    struct Quirks: Codable {
+        var fadtEnableReset: Bool? = false
+        var ignoreForWindows: Bool? = false
+        var normalizeHeaders: Bool? = false
+        var rebaseRegions: Bool? = false
+        var resetLogoStatus: Bool? = false
+
+        private enum CodingKeys: String, CodingKey {
+            case fadtEnableReset = "FadtEnableReset"
+            case ignoreForWindows = "IgnoreForWindows"
+            case normalizeHeaders = "NormalizeHeaders"
+            case rebaseRegions = "RebaseRegions"
+            case resetLogoStatus = "ResetLogoStatus"
+        }
+    }
+}

--- a/OpenCore Configurator/Model/Configuration.swift
+++ b/OpenCore Configurator/Model/Configuration.swift
@@ -1,0 +1,61 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct Configuration: Codable {
+    var acpi: ACPI?
+    var deviceProperties: DeviceProperties?
+    var kernel: Kernel?
+    var miscellaneous: Miscellaneous?
+    var nvram: NVRAM?
+    var platformInfo: PlatformInfo?
+    var uefi: UEFI?
+
+    private enum CodingKeys: String, CodingKey {
+        case acpi = "ACPI"
+        case deviceProperties = "DeviceProperties"
+        case kernel = "Kernel"
+        case miscellaneous = "Misc"
+        case nvram = "NVRAM"
+        case platformInfo = "PlatformInfo"
+        case uefi = "UEFI"
+    }
+
+    enum Value: Codable {
+        case string(String)
+        case int(Int)
+        case data(Data)
+        case empty
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            do {
+                self = try .int(container.decode(Int.self))
+            } catch DecodingError.typeMismatch {
+                do {
+                    self = try .string(container.decode(String.self))
+                } catch DecodingError.typeMismatch {
+                    do {
+                        self = try .data(container.decode(Data.self))
+                    } catch DecodingError.typeMismatch {
+                        throw DecodingError.typeMismatch(Value.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Encoded payload not of an expected type"))
+                    }
+                }
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case let .int(int):
+                try container.encode(int)
+            case let .string(string):
+                try container.encode(string)
+            case let .data(data):
+                try container.encode(data)
+            case .empty:
+                try container.encodeNil()
+            }
+        }
+    }
+}

--- a/OpenCore Configurator/Model/DeviceProperties.swift
+++ b/OpenCore Configurator/Model/DeviceProperties.swift
@@ -1,0 +1,13 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct DeviceProperties: Codable {
+    var additions: [String: [String: Configuration.Value]]?
+    var blocks: [String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case additions = "Add"
+        case blocks = "Block"
+    }
+}

--- a/OpenCore Configurator/Model/Kernel.swift
+++ b/OpenCore Configurator/Model/Kernel.swift
@@ -1,0 +1,95 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct Kernel: Codable {
+    var additions: [Addition]?
+    var blocks: [Block]?
+    var patches: [Patch]?
+    var quirks: Quirks?
+
+    private enum CodingKeys: String, CodingKey {
+        case additions = "Add"
+        case blocks = "Block"
+        case patches = "Patch"
+        case quirks = "Quirk"
+    }
+
+    struct Addition: Codable {
+        var bundlePath: String?
+        var comment: String?
+        var isEnabled: Bool = false
+        var executablePath: String?
+        var matchKernel: String?
+        var plistPath: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case bundlePath = "BundlePath"
+            case comment = "Comment"
+            case isEnabled = "Enabled"
+            case executablePath = "ExecutablePath"
+            case matchKernel = "MatchKernel"
+            case plistPath = "PlistPath"
+        }
+    }
+
+    struct Block: Codable {
+        var comment: String?
+        var isEnabled: Bool
+        var identifier: String?
+        var matchKernel: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case comment = "Comment"
+            case isEnabled = "Enabled"
+            case identifier = "Identifier"
+            case matchKernel = "MatchKernel"
+        }
+    }
+
+    struct Patch: Codable {
+        var base: String?
+        var comment: String?
+        var count: Int?
+        var isEnabled: Bool
+        var find: Data?
+        var identifier: Data?
+        var limit: Int?
+        var mask: Data?
+        var matchKernel: String?
+        var replace: Data?
+        var replaceMask: Data?
+        var skip: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case base = "Base"
+            case comment = "Comment"
+            case count = "Count"
+            case isEnabled = "Enabled"
+            case find = "Find"
+            case identifier = "Identifier"
+            case limit = "Limit"
+            case mask = "Mask"
+            case matchKernel = "MatchKernel"
+            case replace = "Replace"
+            case replaceMask = "ReplaceMask"
+            case skip = "Skip"
+        }
+    }
+
+    struct Quirks: Codable {
+        var appleCpuPmCfgLock: Bool = false
+        var appleXcpmCfgLock: Bool = false
+        var externalDiskIcons: Bool = false
+        var thirdPartyTrim: Bool = false
+        var xhciPortLimit: Bool = false
+
+        private enum CodingKeys: String, CodingKey {
+            case appleCpuPmCfgLock = "AppleCpuPmCfgLock"
+            case appleXcpmCfgLock = "AppleXcpmCfgLock"
+            case externalDiskIcons = "ExternalDiskIcons"
+            case thirdPartyTrim = "ThirdPartyTrim"
+            case xhciPortLimit = "XhciPortLimit"
+        }
+    }
+}

--- a/OpenCore Configurator/Model/Miscellaneous.swift
+++ b/OpenCore Configurator/Model/Miscellaneous.swift
@@ -1,0 +1,70 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct Miscellaneous: Codable {
+    var boot: Boot?
+    var debug: Debug?
+    var security: Security?
+
+    private enum CodingKeys: String, CodingKey {
+        case boot = "Boot"
+        case debug = "Debug"
+        case security = "Security"
+    }
+
+    struct Boot: Codable {
+        var consoleMode: String?
+        var consoleBehaviourOS: ConsoleBehaviour?
+        var consoleBehaviourUI: String?
+        var hideSelf: Bool? = false
+        var resolution: String?
+        var showPicker: Bool? = false
+        var timeout: Int32? = 0
+
+        enum ConsoleBehaviour: String, RawRepresentable, Codable {
+            case text = "Text"
+            case graphics = "Graphics"
+            case forceText = "ForceText"
+            case forceGraphics = "ForceGraphics"
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case consoleMode = "ConsoleMode"
+            case consoleBehaviourOS = "ConsoleBehaviourOS"
+            case consoleBehaviourUI = "ConsoleBehaviourUI"
+            case hideSelf = "HideSelf"
+            case resolution = "Resolution"
+            case showPicker = "ShowPicker"
+            case timeout = "Timeout"
+        }
+    }
+
+    struct Debug: Codable {
+        var disableWatchDog: Bool? = false
+        var displayDelay: Int? = 0
+        var displayLevel: Int64? = 0
+        var target: Int? = 0
+
+        private enum CodingKeys: String, CodingKey {
+            case disableWatchDog = "DisableWatchDog"
+            case displayDelay = "DisplayDelay"
+            case displayLevel = "DisplayLevel"
+            case target = "Target"
+        }
+    }
+
+    struct Security: Codable {
+        var exposeSensitiveData: Int? = 2
+        var haltLevel: Int64? = 0x8000_0000
+        var requireSignature: Bool? = true
+        var requireVault: Bool? = true
+
+        private enum CodingKeys: String, CodingKey {
+            case exposeSensitiveData = "ExposeSensitiveData"
+            case haltLevel = "HaltLevel"
+            case requireSignature = "RequireSignature"
+            case requireVault = "RequireVault"
+        }
+    }
+}

--- a/OpenCore Configurator/Model/NVRAM.swift
+++ b/OpenCore Configurator/Model/NVRAM.swift
@@ -1,0 +1,13 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct NVRAM: Codable {
+    var additions: [String: [String: Configuration.Value]]?
+    var blocks: [String: [String]]?
+
+    private enum CodingKeys: String, CodingKey {
+        case additions = "Add"
+        case blocks = "Block"
+    }
+}

--- a/OpenCore Configurator/Model/PlatformInfo.swift
+++ b/OpenCore Configurator/Model/PlatformInfo.swift
@@ -1,0 +1,159 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct PlatformInfo: Codable {
+    var automatic: Bool = false
+    var updateDataHub: Bool = false
+    var updateNVRAM: Bool = false
+    var updateSMBIOS: Bool = false
+    var updateSMBIOSMode: SMBIOSMode?
+
+    var generic: Generic?
+    var dataHub: DataHub?
+    var platformNVRAM: PlatformNVRAM?
+    var smbios: SMBIOS?
+
+    enum SMBIOSMode: String, RawRepresentable, Codable {
+        case tryOverwrite = "TryOverwrite"
+        case create = "Create"
+        case overwrite = "Overwrite"
+        case custom = "Custom"
+    }
+
+    struct Generic: Codable {
+        var spoofVendor: Bool? = false
+        var systemProductName: String?
+        var systemSerialNumber: String?
+        var systemUUID: String?
+        var mlb: String?
+        var rom: Data?
+
+        private enum CodingKeys: String, CodingKey {
+            case spoofVendor = "SpoofVendor"
+            case systemProductName = "SystemProductName"
+            case systemSerialNumber = "SystemSerialNumber"
+            case systemUUID = "SystemUUID"
+            case mlb = "MLB"
+            case rom = "ROM"
+        }
+    }
+
+    struct DataHub: Codable {
+        var platformName: String?
+        var systemProductName: String?
+        var systemSerialNumber: String?
+        var systemUUID: String?
+        var boardProduct: String?
+        var boardRevision: Data?
+        var startupPowerEvents: Int64?
+        var initialTSC: Int64? = 0
+        var fsbFrequency: Int64?
+        var artFrequency: Int64?
+        var devicePathsSupported: Data?
+        var smcRevision: Data?
+        var smcBranch: Data?
+        var smcPlatform: Data?
+
+        private enum CodingKeys: String, CodingKey {
+            case platformName = "PlatformName"
+            case systemProductName = "SystemProductName"
+            case systemSerialNumber = "SystemSerialNumber"
+            case systemUUID = "SystemUUID"
+            case boardProduct = "BoardProduct"
+            case boardRevision = "BoardRevision"
+            case startupPowerEvents = "StartupPowerEvents"
+            case initialTSC = "InitialTSC"
+            case fsbFrequency = "FSBFrequency"
+            case artFrequency = "ARTFrequency"
+            case devicePathsSupported = "DevicePathsSupported"
+            case smcRevision = "SmcRevision"
+            case smcBranch = "SmcBranch"
+            case smcPlatform = "SmcPlatform"
+        }
+    }
+
+    struct PlatformNVRAM: Codable {
+        var bID: String?
+        var rom: Data?
+        var mlb: String?
+        var firmwareFeatures: Data?
+        var firmwareFeaturesMask: Data?
+
+        private enum CodingKeys: String, CodingKey {
+            case bID = "BID"
+            case rom = "ROM"
+            case mlb = "MLB"
+            case firmwareFeatures = "FirmwareFeatures"
+            case firmwareFeaturesMask = "FirmwareFeaturesMask"
+        }
+    }
+
+    struct SMBIOS: Codable {
+        var biosVendor: String?
+        var biosVersion: String?
+        var biosReleaseDate: String?
+        var systemManufacturer: String?
+        var systemProductName: String?
+        var systemSerialNumber: String?
+        var systemUUID: String?
+        var systemSKUNumber: String?
+        var systemFamily: String?
+        var boardManufacturer: String?
+        var boardProduct: String?
+        var boardVersion: String?
+        var boardSerialNumber: String?
+        var boardAssetTag: String?
+        var boardType: Int?
+        var boardLocationInChassis: String?
+        var chassisManufacturer: String?
+        var chassisType: Int?
+        var chassisSerialNumber: String?
+        var chassisAssetTag: String?
+        var platformFeature: Int?
+        var firmwareFeatures: Data?
+        var firmwareFeaturesMask: Data?
+        var processorType: Int16?
+        var memoryFormFactor: Int8?
+
+        private enum CodingKeys: String, CodingKey {
+            case biosVendor = "BiosVendor"
+            case biosVersion = "BiosVersion"
+            case biosReleaseDate = "BiosReleaseDate"
+            case systemManufacturer = "SystemManufacturer"
+            case systemProductName = "SystemProductName"
+            case systemSerialNumber = "SystemSerialNumber"
+            case systemUUID = "SystemUUID"
+            case systemSKUNumber = "SystemSKUNumber"
+            case systemFamily = "SystemFamily"
+            case boardManufacturer = "BoardManufacturer"
+            case boardProduct = "BoardProduct"
+            case boardVersion = "BoardVersion"
+            case boardSerialNumber = "BoardSerialNumber"
+            case boardAssetTag = "BoardAssetTag"
+            case boardType = "BoardType"
+            case boardLocationInChassis = "BoardLocationInChassis"
+            case chassisManufacturer = "ChassisManufacturer"
+            case chassisType = "ChassisType"
+            case chassisSerialNumber = "ChassisSerialNumber"
+            case chassisAssetTag = "ChassisAssetTag"
+            case platformFeature = "PlatformFeature"
+            case firmwareFeatures = "FirmwareFeatures"
+            case firmwareFeaturesMask = "FirmwareFeaturesMask"
+            case processorType = "ProcessorType"
+            case memoryFormFactor = "MemoryFormFactor"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case automatic = "Automatic"
+        case updateDataHub = "UpdateDataHub"
+        case updateNVRAM = "UpdateNVRAM"
+        case updateSMBIOS = "UpdateSMBIOS"
+        case updateSMBIOSMode = "UpdateSMBIOSMode"
+        case generic = "Generic"
+        case dataHub = "DataHub"
+        case platformNVRAM = "PlatformNVRAM"
+        case smbios = "SMBIOS"
+    }
+}

--- a/OpenCore Configurator/Model/UEFI.swift
+++ b/OpenCore Configurator/Model/UEFI.swift
@@ -1,0 +1,51 @@
+//  Copyright © 2019 notiflux. All rights reserved.
+
+import Foundation
+
+struct UEFI: Codable {
+    var connectDrivers: Bool = false
+    var drivers: [String]?
+    var protocols: Protocols?
+    var quirks: Quirks?
+
+    struct Protocols: Codable {
+        var appleBootPolicy: Bool = false
+        var consoleControl: Bool = false
+        var dataHub: Bool = false
+        var deviceProperties: Bool = false
+
+        private enum CodingKeys: String, CodingKey {
+            case appleBootPolicy = "AppleBootPolicy"
+            case consoleControl = "ConsoleControl"
+            case dataHub = "DataHub"
+            case deviceProperties = "DeviceProperties"
+        }
+    }
+
+    struct Quirks: Codable {
+        var exitBootServicesDelay: Int = 0
+        var ignoreInvalidFlexRatio: Bool = false
+        var ignoreTextInGraphics: Bool = false
+        var provideConsoleGOP: Bool = false
+        var releaseUSBOwnership: Bool = false
+        var requestBootVariableRouting: Bool = false
+        var sanitiseClearScreen: Bool = false
+
+        private enum CodingKeys: String, CodingKey {
+            case exitBootServicesDelay = "ExitBootServicesDelay"
+            case ignoreInvalidFlexRatio = "IgnoreInvalidFlexRatio"
+            case ignoreTextInGraphics = "IgnoreTextInGraphics"
+            case provideConsoleGOP = "ProvideConsoleGOP"
+            case releaseUSBOwnership = "ReleaseUSBOwnership"
+            case requestBootVariableRouting = "RequestBootVariableRouting"
+            case sanitiseClearScreen = "SanitiseClearScreen"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case connectDrivers = "ConnectDrivers"
+        case drivers = "Drivers"
+        case protocols = "Protocols"
+        case quirks = "Quirks"
+    }
+}


### PR DESCRIPTION
This PR aims to decode and encode the configuration property lists using Swift's Codable protocol. 

The PR is currently a work in progress, and is not ready for use.

```swift
let data = try Data(contentsOf: openedFileURL)
let decoder = PropertyListDecoder()
let configuration = try decoder.decode(Configuration.self, from: data)
```

## What's left to do?

- [ ] Refine the model - this is a first pass, and some of the models (notably `DeviceProperties` and `NVRAM`) are basically glorified dictionaries right now.
- [ ] Decoding model to memory for use when the user opens a file
- [ ] Using the model to populate a proper document, as well as views
- [ ] Saving model back to disk
    - [ ] Saving should omit values that are equal to their defaults