### PR TITLE
Remove unnecessary Objective-C bridging header

### DIFF
--- a/OpenCore Configurator.xcodeproj/project.pbxproj
+++ b/OpenCore Configurator.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		7F961CCB2270974E007F0BBE /* KernelPopoverController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KernelPopoverController.swift; sourceTree = "<group>"; };
 		7F9A2A6E228D9B7A00CCC12B /* acpiDifferController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = acpiDifferController.swift; sourceTree = "<group>"; };
 		7FA19C072296B59300954C46 /* vaultPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = vaultPlist.swift; sourceTree = "<group>"; };
-		7FA19C092296CB1B00954C46 /* OpenCore-Configurator-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OpenCore-Configurator-Bridging-Header.h"; sourceTree = "<group>"; };
 		7FEADAE82295C775009800DD /* vaultManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = vaultManager.swift; sourceTree = "<group>"; };
 		7FF918A8227226A60081891E /* openHandlerFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = openHandlerFunctions.swift; sourceTree = "<group>"; };
 		810042401ECA33DF009FE633 /* OpenCore Configurator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenCore Configurator.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -135,7 +134,6 @@
 				7F3AAC172279BB55006644AD /* saveHandlerFunctions.swift */,
 				7FEADAE82295C775009800DD /* vaultManager.swift */,
 				9021990F2290CD2700C7A73D /* Supporting Files */,
-				7FA19C092296CB1B00954C46 /* OpenCore-Configurator-Bridging-Header.h */,
 			);
 			path = "OpenCore Configurator";
 			sourceTree = "<group>";
@@ -478,7 +476,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.notiflux.OpenCore-Configurator";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "OpenCore Configurator/OpenCore-Configurator-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -495,7 +492,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.notiflux.OpenCore-Configurator";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "OpenCore Configurator/OpenCore-Configurator-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/OpenCore Configurator/OpenCore-Configurator-Bridging-Header.h
+++ b/OpenCore Configurator/OpenCore-Configurator-Bridging-Header.h
@@ -1,6 +1,0 @@
-#ifndef OpenCore_Configurator_Bridging_Header_h
-#define OpenCore_Configurator_Bridging_Header_h
-#import <CommonCrypto/CommonDigest.h>
-
-
-#endif /* OpenCore_Configurator_Bridging_Header_h */

--- a/OpenCore Configurator/vaultManager.swift
+++ b/OpenCore Configurator/vaultManager.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import CommonCrypto.CommonDigest
 
 var dataSource: [[String: String]] = [[String: String]]()
 var requireVault: Bool = false


### PR DESCRIPTION
CommonCrypto can be directly imported into Swift - there's no reason to introduce the overhead and potential problems of a bridging header.