### PR TITLE
Update from Master to Main

### DIFF
--- a/OpenCore Configurator/ViewController.swift
+++ b/OpenCore Configurator/ViewController.swift
@@ -329,7 +329,7 @@ class ViewController: NSViewController {
 
             // I stole this from MaciASL
             // TODO: write tables to file (xxd -r -p) and show differences
-        let expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("AppleACPIPlatformExpert"))
+        let expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleACPIPlatformExpert"))
         acpiTables = IORegistryEntryCreateCFProperty(expert, ("ACPI Tables" as CFString), kCFAllocatorDefault, 0)?.takeRetainedValue() as! NSMutableDictionary
         
         


### PR DESCRIPTION
update "kIOMasterPortDefault" to "kIOMainPortDefault" fix for MacOS 13.3